### PR TITLE
Add CI workflow (+ Makefile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request: {}
+  push:
+    branches: [ master ]
+
+jobs:
+  build-c:
+    name: Build (C)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout files in the repository
+        uses: actions/checkout@v3
+
+      - name: Builds C implementation
+        run: cd c && make

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,0 +1,15 @@
+SRC = bfc.c bfops.c
+OBJ = $(subst .c,.o,$(SRC))
+
+.PHONY = all clean
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $^ -o $@
+
+bf: $(OBJ)
+	$(CC) $(CFLAGS) $^ -o $@
+
+all: bf
+
+clean:
+	$(RM) *.o bf


### PR DESCRIPTION
Add a Makefile for the interpreter written in C and a CI workflow that builds
that interpreter. In the future, the workflow should take care of running tests
for each interpreter implemented in the repository.
