### PR TITLE
CI: add cache and coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,17 @@ jobs:
       - name: Build, test and generate coverage report
         run: stack test --coverage
 
+      - name: Generate codecov report
+        working-directory: .
+        run: |
+          stack install hpc-codecov
+          hpc-codecov -r haskell stack:brainfuck-test -o haskell/codecov.json
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: haskell/codecov.json
+
       - name: Run example (e2e?) tests
         run: ./test/bats/bin/bats ./test/haskell.bats
         working-directory: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,17 +61,35 @@ jobs:
       - name: Build, test and generate coverage report
         run: stack test --coverage
 
+      - name: Run example (e2e?) tests
+        run: ./test/bats/bin/bats ./test/haskell.bats
+        working-directory: .
+
       - name: Generate codecov report
         working-directory: .
         run: |
           stack install hpc-codecov
           hpc-codecov -r haskell stack:brainfuck-test -o haskell/codecov.json
 
+      - name: Cache the coverage report for reuse
+        uses: actions/cache@v3
+        with:
+          path: haskell/codecov.json
+          key: haskell-codecov-json-${{ github.sha }}
+
+  codecov:
+    name: Codecov
+    runs-on: ubuntu-latest
+    needs: [ build-hs ]
+
+    steps:
+      - name: Restore Haskell coverage report
+        uses: actions/cache@v3
+        with:
+          path: haskell/codecov.json
+          key: haskell-codecov-json-${{ github.sha }}
+
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
           files: haskell/codecov.json
-
-      - name: Run example (e2e?) tests
-        run: ./test/bats/bin/bats ./test/haskell.bats
-        working-directory: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,8 @@ jobs:
           restore-keys: |
             stack-work-
 
-      - name: Build Haskell implementation
-        run: stack build
-
-      - name: Run unit tests
-        run: stack test
+      - name: Build, test and generate coverage report
+        run: stack test --coverage
 
       - name: Run example (e2e?) tests
         run: ./test/bats/bin/bats ./test/haskell.bats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,22 @@ jobs:
           stack-version: latest
           stack-no-global: true
 
+      - name: Cache ~/.stack
+        uses: actions/cache@v3
+        with:
+          path: ~/.stack
+          key: stack-global-${{ hashFiles('stack.yaml') }}
+          restore-keys: |
+            stack-global-
+
+      - name: Cache .stack-work
+        uses: actions/cache@v3
+        with:
+          path: haskell/.stack-work
+          key: stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('**/*.hs') }}
+          restore-keys: |
+            stack-work-
+
       - name: Build Haskell implementation
         run: stack build
 

--- a/test/haskell.bats
+++ b/test/haskell.bats
@@ -5,6 +5,9 @@ setup() {
   load 'helper/bats-assert/load'
 
   cd "$BATS_TEST_DIRNAME/../haskell"
+
+  # Ensure proper binaries have been compiled.
+  stack build
 }
 
 @test "hello world program" {


### PR DESCRIPTION
Cache the Stack directories to avoid rebuilding dependencies and the like, and ultimately send a coverage report to codecov.
